### PR TITLE
Search bar filters on both title and content + Working "show all" button

### DIFF
--- a/src/categories/topics.js
+++ b/src/categories/topics.js
@@ -30,11 +30,11 @@ module.exports = function (Categories) {
                 const allPids = await topics.getPids(topicObj.tid);
                 const contents = await posts.getPostsFields(allPids, ['content']);
                 return contents.filter(c => c.content.toLowerCase().includes(searchLowerCase)).length;
-            }
+            };
             // https://stackoverflow.com/questions/71600782/async-inside-filter-function-in-javascript
-            results.topics = (await Promise.all(results.topics.map(async(topicObj) => ({
+            results.topics = (await Promise.all(results.topics.map(async topicObj => ({
                 value: topicObj,
-                include: await pred(topicObj)
+                include: await pred(topicObj),
             })))).filter(v => v.include).map(data => data.value);
         }
         return { topics: results.topics, nextStart: data.stop + 1 };

--- a/src/topics/index.js
+++ b/src/topics/index.js
@@ -58,26 +58,6 @@ Topics.getTopics = async function (tids, options) {
     return await Topics.getTopicsByTids(tids, options);
 };
 
-Topics.getTopicsByTitle = async function (input, cid) {
-    if (typeof input !== 'string') {
-        return null;
-    }
-    const search = input.trim().toLowerCase();
-    let all_topics_list = [];
-    all_topics_list = await db.getSortedSetRange(`cid:${cid}:tids`, 0, -1);
-    const title_list = [];
-    for (let i = 0; i < all_topics_list.length; i++) {
-        title_list[i] = db.getObjectsFields(`topic:${all_topics_list[i]}`, ['tid', 'title']);
-    }
-    const res = [];
-    for (let i = 0; i < title_list.length; i++) {
-        if (title_list[i].title.includes(search)) {
-            res.push(title_list[i].tid);
-        }
-    }
-    return res;
-};
-
 Topics.getTopicsByTids = async function (tids, options) {
     if (!Array.isArray(tids) || !tids.length) {
         return [];

--- a/src/topics/sorted.js
+++ b/src/topics/sorted.js
@@ -112,7 +112,7 @@ module.exports = function (Topics) {
         if (params.term === 'alltime' && !params.cids && !params.tags.length && params.filter !== 'watched' && !params.floatPinned) {
             return tids;
         }
-        const topicData = await Topics.getTopicsFields(tids, ['tid', 'lastposttime', 'upvotes', 'downvotes', 'postcount', 'pinned', 'related']);
+        const topicData = await Topics.getTopicsFields(tids, ['tid', 'lastposttime', 'upvotes', 'downvotes', 'postcount', 'pinned']);
         const sortMap = {
             recent: sortRecent,
             old: sortOld,

--- a/themes/nodebb-theme-persona/less/bootstrap/searchcontainer.less
+++ b/themes/nodebb-theme-persona/less/bootstrap/searchcontainer.less
@@ -1,69 +1,24 @@
 @import "normalize.less";
-  
-.topnav {
-  overflow: hidden;
-  background-color: #e9e9e9;
-}
 
-.topnav a {
-  float: left;
-  display: block;
-  color: black;
-  text-align: center;
-  padding: 14px 16px;
-  text-decoration: none;
-  font-size: 17px;
-}
-
-.topnav a:hover {
-  background-color: #ddd;
-  color: black;
-}
-
-.topnav a.active {
-  background-color: #2196F3;
-  color: white;
-}
-
-.topnav .search-container {
+.search-container {
   float: right;
+  border: 0;
+  outline: 0;
+  border-bottom: 2px solid blue;
 }
 
-.topnav input[type=text] {
-  padding: 6px;
-  margin-top: 8px;
-  font-size: 17px;
-  border: none;
-}
-
-.topnav .search-container button {
-  float: right;
-  padding: 6px;
-  margin-top: 8px;
-  margin-right: 16px;
-  background: #ddd;
-  font-size: 17px;
-  border: none;
-  cursor: pointer;
-}
-
-.topnav .search-container button:hover {
-  background: #ccc;
-}
-
-@media screen and (max-width: 600px) {
-  .topnav .search-container {
-      float: none;
+.search-box {
+    float: right;
+    border: 0;
+    outline: 0;
+    border-bottom: 2px solid blue;
   }
-  .topnav a, .topnav input[type=text], .topnav .search-container button {
-      float: none;
-      display: block;
-      text-align: left;
-      width: 100%;
-      margin: 0;
-      padding: 14px;
-  }
-  .topnav input[type=text] {
-      border: 1px solid #ccc;  
-  }
+
+.input {
+//   padding: 6px;
+//   margin-top: 8px;
+//   font-size: 17px;
+  border: 0;
+  outline: 0;
+  border-bottom: 2px solid blue;
 }

--- a/themes/nodebb-theme-persona/templates/category.tpl
+++ b/themes/nodebb-theme-persona/templates/category.tpl
@@ -21,9 +21,9 @@
                 <div class="alert alert-warning hide" id="new-topics-alert"></div>
             </a>
             <span class="pull-right" component="category/controls">
+                <!-- IMPORT partials/topic/sorttopics.tpl -->
                 <!-- IMPORT partials/category/watch.tpl -->
                 <!-- IMPORT partials/category/sort.tpl -->
-                <!-- IMPORT partials/topic/sorttopics.tpl -->
             </span>
         </div>
 

--- a/themes/nodebb-theme-persona/templates/category.tpl
+++ b/themes/nodebb-theme-persona/templates/category.tpl
@@ -20,6 +20,7 @@
             <a href="{url}" class="inline-block">
                 <div class="alert alert-warning hide" id="new-topics-alert"></div>
             </a>
+
             <span class="pull-right" component="category/controls">
                 <!-- IMPORT partials/topic/sorttopics.tpl -->
                 <!-- IMPORT partials/category/watch.tpl -->

--- a/themes/nodebb-theme-persona/templates/partials/topic/sorttopics.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/sorttopics.tpl
@@ -1,6 +1,8 @@
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+
 <form name="searchTopics" style = "display:inline" action="{config.relative_path}/category/{../slug}" method="GET">
         <input class="search-box" type="text" placeholder="Search..." name="searchTopics">
-        <button class="btn btn-default" type="submit" onClick="return getRecentPosts()">Submit</button>
+        <button class="btn btn-default" type="submit"><i class="fa fa-search"></i></button>
 </form>
 <style>
 .search-container {

--- a/themes/nodebb-theme-persona/templates/partials/topic/sorttopics.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/sorttopics.tpl
@@ -1,8 +1,6 @@
-<form name="searchTopics" action="{config.relative_path}/category/{../slug}" method="GET">
-    <div class="search-container">
+<form class="search-container" name="searchTopics" action="{config.relative_path}/category/{../slug}" method="GET">
         <input class="search-box" type="text" placeholder="Search..." name="searchTopics">
         <button class="btn btn-default" type="submit" onClick="return getRecentPosts()">Submit</button>
-    </div>
 </form>
 <style>
 .search-container {
@@ -22,17 +20,18 @@
     &::placeholder {
         color: color(#575756 a(0.8));
         text-transform: uppercase;
-        letter-spacing: 1.5px;
+        letter-spacing: 1.5px;  
     }
 
     &:hover,
         &:focus {
+            display: inline-block;
+            white-space: nowrap;
             padding: 12px 0;
             outline: 0;
             border: 1px solid transparent;
             border-bottom: 1px solid #575756;
             border-radius: 0;
-            background-position: 100% center;
         }
 }
 </style>

--- a/themes/nodebb-theme-persona/templates/partials/topic/sorttopics.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/sorttopics.tpl
@@ -1,4 +1,4 @@
-<form class="search-container" name="searchTopics" action="{config.relative_path}/category/{../slug}" method="GET">
+<form name="searchTopics" style = "display:inline" action="{config.relative_path}/category/{../slug}" method="GET">
         <input class="search-box" type="text" placeholder="Search..." name="searchTopics">
         <button class="btn btn-default" type="submit" onClick="return getRecentPosts()">Submit</button>
 </form>
@@ -8,7 +8,7 @@
 }
 
 .search-box {
-    display: inline-flex;
+    display: inline;
     margin-bottom: 0;
     background-color: transparent;
     font-size: 11px;

--- a/themes/nodebb-theme-persona/templates/partials/topic/sorttopics.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/sorttopics.tpl
@@ -4,6 +4,9 @@
         <input class="search-box" type="text" placeholder="Search..." name="searchTopics">
         <button class="btn btn-default" type="submit"><i class="fa fa-search"></i></button>
 </form>
+<form name="showAll" style = "display:inline" formaction="{config.relative_path}/category/{../slug}" method="GET">
+    <button name="showAll" class="btn btn-default" type="submit">Show all posts</button>
+</form>
 <style>
 .search-container {
     padding-top: -20px;

--- a/themes/nodebb-theme-persona/templates/partials/topic/sorttopics.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/sorttopics.tpl
@@ -1,7 +1,38 @@
-<div class="search-container" component="thread/sort">
-    <button class="btn btn-search" data-toggle="search-container" type="button">
-      <form name="searchTopics" action="{config.relative_path}/category/{../slug}" method="GET">
-      <input type="text" class="related" data-sort="related" placeholder="Search..." name="searchTopics">
-      </form>
-    <button class="btn btn-default" type="submit" onClick="return getRecentPosts()">Submit</button>
-</div>
+<form name="searchTopics" action="{config.relative_path}/category/{../slug}" method="GET">
+    <div class="search-container">
+        <input class="search-box" type="text" placeholder="Search..." name="searchTopics">
+        <button class="btn btn-default" type="submit" onClick="return getRecentPosts()">Submit</button>
+    </div>
+</form>
+<style>
+.search-container {
+    padding-top: 16px;
+}
+
+.search-box {
+    display: inline-block;
+    margin-bottom: 0;
+    padding: 8px 16px;
+    white-space: nowrap;
+    background-color: transparent;
+    transition: transform 250ms ease-in-out;
+    font-size: 11px;
+    line-height: 13px;
+    
+    &::placeholder {
+        color: color(#575756 a(0.8));
+        text-transform: uppercase;
+        letter-spacing: 1.5px;
+    }
+
+    &:hover,
+        &:focus {
+            padding: 12px 0;
+            outline: 0;
+            border: 1px solid transparent;
+            border-bottom: 1px solid #575756;
+            border-radius: 0;
+            background-position: 100% center;
+        }
+}
+</style>

--- a/themes/nodebb-theme-persona/templates/partials/topic/sorttopics.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/sorttopics.tpl
@@ -15,10 +15,14 @@
     line-height: 13px;
     padding: 12px;
     outline: 0;
-    text-transform: uppercase;
-    letter-spacing: 1.5px; 
     border: 1px solid transparent;
     border-bottom: 1px solid #575756;
     border-radius: 0;
+
+    &::placeholder {
+        color: color(#575756 a(0.8));
+        text-transform: uppercase;
+        letter-spacing: 1.5px;
+    }
 }
 </style>

--- a/themes/nodebb-theme-persona/templates/partials/topic/sorttopics.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/sorttopics.tpl
@@ -5,7 +5,7 @@
         <button class="btn btn-default" type="submit"><i class="fa fa-search"></i></button>
 </form>
 <form name="showAll" style = "display:inline" formaction="{config.relative_path}/category/{../slug}" method="GET">
-    <button name="showAll" class="btn btn-default" type="submit">Show all topics</button>
+    <button class="btn btn-default" type="submit">Show all topics</button>
 </form>
 <style>
 .search-container {

--- a/themes/nodebb-theme-persona/templates/partials/topic/sorttopics.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/sorttopics.tpl
@@ -4,34 +4,21 @@
 </form>
 <style>
 .search-container {
-    padding-top: 16px;
+    padding-top: -20px;
 }
 
 .search-box {
-    display: inline-block;
+    display: inline-flex;
     margin-bottom: 0;
-    padding: 8px 16px;
-    white-space: nowrap;
     background-color: transparent;
-    transition: transform 250ms ease-in-out;
     font-size: 11px;
     line-height: 13px;
-    
-    &::placeholder {
-        color: color(#575756 a(0.8));
-        text-transform: uppercase;
-        letter-spacing: 1.5px;  
-    }
-
-    &:hover,
-        &:focus {
-            display: inline-block;
-            white-space: nowrap;
-            padding: 12px 0;
-            outline: 0;
-            border: 1px solid transparent;
-            border-bottom: 1px solid #575756;
-            border-radius: 0;
-        }
+    padding: 12px;
+    outline: 0;
+    text-transform: uppercase;
+    letter-spacing: 1.5px; 
+    border: 1px solid transparent;
+    border-bottom: 1px solid #575756;
+    border-radius: 0;
 }
 </style>

--- a/themes/nodebb-theme-persona/templates/partials/topic/sorttopics.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/sorttopics.tpl
@@ -5,7 +5,7 @@
         <button class="btn btn-default" type="submit"><i class="fa fa-search"></i></button>
 </form>
 <form name="showAll" style = "display:inline" formaction="{config.relative_path}/category/{../slug}" method="GET">
-    <button name="showAll" class="btn btn-default" type="submit">Show all posts</button>
+    <button name="showAll" class="btn btn-default" type="submit">Show all topics</button>
 </form>
 <style>
 .search-container {


### PR DESCRIPTION
#### There are two changes in this PR:
1. (MAJOR) Search functionality has been extended
2. (MINOR) "Show all posts" convenience button has been added

#### (MAJOR) Search functionality has been extended
The search bar now filters on two things:
1. The titles of topics
4. The content/body of the posts under topics

If either one of the two contains the search input, the topic will be displayed under the search results. The search is not capital-sensitive, so topics containing "Welcome" and "welcome" will both be displayed under either input. The search **does not** accept misspelled inputs, so if someone inputs "welceme", it will not show any posts that don't contain the exact string "welceme" (i.e. it will not show posts with "welcome").

#### Things left to do for the search bar:
1. Add type annotations because the added code is in JS not TS
2. Write tests for search functionality

#### (MINOR) "Show all posts" convenience button has been added
I added a "Show all topics" button, which shows all of the topics in a category even after a search has been made, effectively removing the filtering that a search has placed on the topic list. This is a much nicer alternative to having to use the back page button in the browser or having to click on the category name every time a user wants to see the full topic list. You could argue that this feature is not related to the changes above and should have its own PR, but it's literally 3 lines, so I thought it was small enough to be tacked on to this PR.

#### Testing and Linter status for the additions:
All tests pass locally and there are no linter issues.