### PR TITLE
Added Search Bar Functionality Testing For Case Sensitive Input

### DIFF
--- a/test/categories.js
+++ b/test/categories.js
@@ -898,6 +898,43 @@ describe('Categories', () => {
         });
     });
 
+    it('should not be case-sensitive when searching for topics by keyword in description', (done) => {
+        const keyword = 'Welcome'; // case-insensitive keyword
+        const mixedCaseKeyword = 'wElCoMe'; // mixed-case keyword
+    
+        Topics.create({
+            uid: 1,
+            cid: categoryObj.cid,
+            title: 'Case Insensitive Topic',
+            content: 'Welcome to the forum!',
+        }, (err) => {
+            assert.ifError(err);
+    
+            Categories.getCategoryTopics({
+                cid: categoryObj.cid,
+                start: 0,
+                stop: 10,
+                uid: 0,
+                keyword: mixedCaseKeyword,
+                sort: 'oldest_to_newest',
+            }, (err, result) => {
+                assert.equal(err, null);
+                assert(Array.isArray(result.topics));
+    
+                const containsKeyword = result.topics.some((topic) => {
+                    return topic.content.includes(keyword) || topic.content.includes(mixedCaseKeyword);
+                });
+    
+                assert(containsKeyword);
+    
+                done();
+            });
+        });
+    });
+    
+
+    
+
     it('should return nested children categories', async () => {
         const rootCategory = await Categories.create({ name: 'root' });
         const child1 = await Categories.create({ name: 'child1', parentCid: rootCategory.cid });

--- a/test/categories.js
+++ b/test/categories.js
@@ -910,4 +910,27 @@ describe('Categories', () => {
         assert.strictEqual(child1.cid, data.children[0].cid);
         assert.strictEqual(child2.cid, data.children[0].children[0].cid);
     });
+
+    it('should not be case-sensitive when searching for topics by keyword in description', (done) => {
+        const keyword = 'Welcome';
+        const mixedCaseKeyword = 'wElCoMe';
+        (err) => {
+            assert.ifError(err);
+            Categories.getCategoryTopics({
+                cid: categoryObj.cid,
+                start: 0,
+                stop: 10,
+                uid: 0,
+                keyword: mixedCaseKeyword,
+                sort: 'oldest_to_newest',
+            }, (err, result) => {
+                assert.equal(err, null);
+                assert(Array.isArray(result.topics));
+                const currkey = result.topics.some(topic => topic.content.includes(keyword));
+                const mixkey = result.topics.some(topic => topic.content.includes(mixedCaseKeyword));
+                const containsKeyword = currkey || mixkey;
+                assert(containsKeyword);
+            });
+        }
+    });
 });

--- a/test/categories.js
+++ b/test/categories.js
@@ -931,9 +931,9 @@ describe('Categories', () => {
             }, (err, result) => {
                 assert.equal(err, null);
                 assert(Array.isArray(result.topics));
-                const containsKeyword = result.topics.some(topic =>
+                const containsKeyword = result.topics.some((topic) => (
                     topic.content.includes(keyword) || topic.content.includes(mixedCaseKeyword)
-                );
+                ));
                 assert(containsKeyword);
                 done();
             });

--- a/test/categories.js
+++ b/test/categories.js
@@ -911,7 +911,6 @@ describe('Categories', () => {
         assert.strictEqual(child1.cid, data.children[0].cid);
         assert.strictEqual(child2.cid, data.children[0].children[0].cid);
     });
-    
     it('should not be case-sensitive when searching for topics by keyword in description', (done) => {
         const keyword = 'Welcome';
         const mixedCaseKeyword = 'wElCoMe';
@@ -932,9 +931,9 @@ describe('Categories', () => {
             }, (err, result) => {
                 assert.equal(err, null);
                 assert(Array.isArray(result.topics));
-                const containsKeyword = result.topics.some((topic) => {
-                    return topic.content.includes(keyword) || topic.content.includes(mixedCaseKeyword);
-                });
+                const containsKeyword = result.topics.some(topic =>
+                    topic.content.includes(keyword) || topic.content.includes(mixedCaseKeyword)
+                );
                 assert(containsKeyword);
                 done();
             });

--- a/test/categories.js
+++ b/test/categories.js
@@ -898,43 +898,6 @@ describe('Categories', () => {
         });
     });
 
-    it('should not be case-sensitive when searching for topics by keyword in description', (done) => {
-        const keyword = 'Welcome'; // case-insensitive keyword
-        const mixedCaseKeyword = 'wElCoMe'; // mixed-case keyword
-    
-        Topics.create({
-            uid: 1,
-            cid: categoryObj.cid,
-            title: 'Case Insensitive Topic',
-            content: 'Welcome to the forum!',
-        }, (err) => {
-            assert.ifError(err);
-    
-            Categories.getCategoryTopics({
-                cid: categoryObj.cid,
-                start: 0,
-                stop: 10,
-                uid: 0,
-                keyword: mixedCaseKeyword,
-                sort: 'oldest_to_newest',
-            }, (err, result) => {
-                assert.equal(err, null);
-                assert(Array.isArray(result.topics));
-    
-                const containsKeyword = result.topics.some((topic) => {
-                    return topic.content.includes(keyword) || topic.content.includes(mixedCaseKeyword);
-                });
-    
-                assert(containsKeyword);
-    
-                done();
-            });
-        });
-    });
-    
-
-    
-
     it('should return nested children categories', async () => {
         const rootCategory = await Categories.create({ name: 'root' });
         const child1 = await Categories.create({ name: 'child1', parentCid: rootCategory.cid });
@@ -947,5 +910,34 @@ describe('Categories', () => {
         });
         assert.strictEqual(child1.cid, data.children[0].cid);
         assert.strictEqual(child2.cid, data.children[0].children[0].cid);
+    });
+    
+    it('should not be case-sensitive when searching for topics by keyword in description', (done) => {
+        const keyword = 'Welcome';
+        const mixedCaseKeyword = 'wElCoMe';
+        Topics.create({
+            uid: 1,
+            cid: categoryObj.cid,
+            title: 'Case Insensitive Topic',
+            content: 'Welcome to the forum!',
+        }, (err) => {
+            assert.ifError(err);
+            Categories.getCategoryTopics({
+                cid: categoryObj.cid,
+                start: 0,
+                stop: 10,
+                uid: 0,
+                keyword: mixedCaseKeyword,
+                sort: 'oldest_to_newest',
+            }, (err, result) => {
+                assert.equal(err, null);
+                assert(Array.isArray(result.topics));
+                const containsKeyword = result.topics.some((topic) => {
+                    return topic.content.includes(keyword) || topic.content.includes(mixedCaseKeyword);
+                });
+                assert(containsKeyword);
+                done();
+            });
+        });
     });
 });

--- a/test/categories.js
+++ b/test/categories.js
@@ -911,32 +911,4 @@ describe('Categories', () => {
         assert.strictEqual(child1.cid, data.children[0].cid);
         assert.strictEqual(child2.cid, data.children[0].children[0].cid);
     });
-    it('should not be case-sensitive when searching for topics by keyword in description', (done) => {
-        const keyword = 'Welcome';
-        const mixedCaseKeyword = 'wElCoMe';
-        Topics.create({
-            uid: 1,
-            cid: categoryObj.cid,
-            title: 'Case Insensitive Topic',
-            content: 'Welcome to the forum!',
-        }, (err) => {
-            assert.ifError(err);
-            Categories.getCategoryTopics({
-                cid: categoryObj.cid,
-                start: 0,
-                stop: 10,
-                uid: 0,
-                keyword: mixedCaseKeyword,
-                sort: 'oldest_to_newest',
-            }, (err, result) => {
-                assert.equal(err, null);
-                assert(Array.isArray(result.topics));
-                const containsKeyword = result.topics.some(topic => {
-                    return topic.content.includes(keyword) || topic.content.includes(mixedCaseKeyword)
-                });
-                assert(containsKeyword);
-                done();
-            });
-        });
-    });
 });

--- a/test/categories.js
+++ b/test/categories.js
@@ -931,9 +931,9 @@ describe('Categories', () => {
             }, (err, result) => {
                 assert.equal(err, null);
                 assert(Array.isArray(result.topics));
-                const containsKeyword = result.topics.some((topic) => (
-                    topic.content.includes(keyword) || topic.content.includes(mixedCaseKeyword)
-                ));
+                const containsKeyword = result.topics.some(topic => {
+                    return topic.content.includes(keyword) || topic.content.includes(mixedCaseKeyword)
+                });
                 assert(containsKeyword);
                 done();
             });

--- a/test/categories.js
+++ b/test/categories.js
@@ -897,7 +897,6 @@ describe('Categories', () => {
             });
         });
     });
-
     it('should return nested children categories', async () => {
         const rootCategory = await Categories.create({ name: 'root' });
         const child1 = await Categories.create({ name: 'child1', parentCid: rootCategory.cid });


### PR DESCRIPTION
- wrote test cases for https://github.com/CMU-313/fall23-nodebb-slam/issues/44 in test/categories.js
- the main test case written was to check for case sensitivity, since the search bar is not capital-sensitive (ex. topics containing "weLCOME" and "Welcome" are both displayed in result list)