### PR TITLE
Integrate static analysis tool Flow

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -44,6 +44,13 @@ function find_compiled_js() {
     module.exports = {
         extends: ["nodebb"],
         root: true,
+        parser: 'hermes-eslint',
+        plugins: [
+        'ft-flow'
+        ],
+        extends: [
+        'plugin:ft-flow/recommended',
+        ],
         ignorePatterns: find_compiled_js(),
         rules: {
             "indent": ["error", 4]
@@ -63,7 +70,9 @@ function find_compiled_js() {
                 },
                 rules: {
                     "no-use-before-define": "off",
-                    "@typescript-eslint/no-use-before-define": "error",			
+                    "@typescript-eslint/no-use-before-define": "error",	
+                    "no-prototype-builtins": "off",
+                    "import/order": "off",
                 }
             }
         ]

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -46,11 +46,18 @@ function find_compiled_js() {
         root: true,
         parser: 'hermes-eslint',
         plugins: [
-        'ft-flow'
+            'ft-flow'
         ],
         extends: [
-        'plugin:ft-flow/recommended',
+            'plugin:ft-flow/recommended',
         ],
+        rules: {
+            "no-use-before-define": "off",
+            "no-prototype-builtins": "off",
+            "import/order": "off",
+            "no-empty": "off",
+            "no-constant-condition": "off",
+        },
         ignorePatterns: find_compiled_js(),
         rules: {
             "indent": ["error", 4]

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -78,6 +78,7 @@ jobs:
             }
         run: |
           node app --setup="${SETUP}" --ci="${CI}"
+          npm install eslint-plugin-ft-flow@latest --save-dev
 
       - name: Run ESLint
         run: npm run lint

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ theme/*.sublime-workspace
 theme/.idea
 theme/.vscode
 theme/node_modules/
+
+# stryker temp files
+.stryker-tmp

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/order */
-
 'use strict';
 
 const fs = require('fs');

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -98,7 +98,7 @@ prestart.versionCheck();
 
 if (!configExists && process.argv[2] !== 'setup') {
     require('./setup').webInstall();
-    return;
+    // return;
 }
 
 process.env.CONFIG = configFile;

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -1,7 +1,9 @@
+/* @noflow */
 export type Stats = {
   stats: Stat[];
 };
 
+/* @noflow */
 export type Stat = {
   yesterday: number;
   today: number;
@@ -19,6 +21,7 @@ export type Stat = {
   name: string;
 } & StatOptionalProperties;
 
+/* @noflow */
 export type StatOptionalProperties = {
   name: string;
   href: string;

--- a/src/types/breadcrumbs.ts
+++ b/src/types/breadcrumbs.ts
@@ -1,7 +1,9 @@
+/* @noflow */
 export type Breadcrumbs = {
   breadcrumbs: Breadcrumb[];
 };
 
+/* @noflow */
 export type Breadcrumb = {
   text: string;
   url: string;

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -1,3 +1,4 @@
+/* @noflow */
 export type CategoryObject = {
   cid: number;
   name: string;
@@ -25,6 +26,7 @@ export type CategoryObject = {
   subCategoriesPerPage: number;
 };
 
+/* @noflow */
 export type CategoryOptionalProperties = {
   cid: number;
   backgroundImage: string;

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,5 +1,6 @@
 import { UserObjectSlim } from './user';
 
+/* @noflow */
 export type MessageObject = {
   content: string;
   timestamp: number;
@@ -17,6 +18,7 @@ export type MessageObject = {
   cleanedContent: string;
 };
 
+/* @noflow */
 export type RoomObject = {
   owner: number;
   roomId: number;
@@ -24,10 +26,12 @@ export type RoomObject = {
   groupChat: boolean;
 };
 
+/* @noflow */
 export type RoomUserList = {
   users: UserObjectSlim[];
 };
 
+/* @noflow */
 export type RoomObjectFull = {
   isOwner: boolean;
   users: UserObjectSlim[];

--- a/src/types/commonProps.ts
+++ b/src/types/commonProps.ts
@@ -1,5 +1,6 @@
 import { TagObject } from './tag';
 
+/* @noflow */
 export type CommonProps = {
   loggedIn: boolean;
   relative_path: string;
@@ -10,15 +11,18 @@ export type CommonProps = {
   widgets: Widget[];
 };
 
+/* @noflow */
 export interface Template {
   name: string;
 }
 
+/* @noflow */
 export interface Header {
   tags: TagObject[];
   link: Link[];
 }
 
+/* @noflow */
 export interface Link {
   rel: string;
   type: string;
@@ -28,6 +32,7 @@ export interface Link {
   as: string;
 }
 
+/* @noflow */
 export interface Widget {
   html: string;
 }

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -1,5 +1,6 @@
 import { StatusObject } from './status';
 
+/* @noflow */
 export type ErrorObject = {
   status: StatusObject;
 };

--- a/src/types/flag.ts
+++ b/src/types/flag.ts
@@ -1,5 +1,6 @@
 import { UserObjectSlim } from './user';
 
+/* @noflow */
 export type FlagHistoryObject = {
   history: History[];
 };
@@ -20,11 +21,12 @@ interface Meta {
   labelClass: string;
 }
 
+/* @noflow */
 export type FlagNotesObject = {
   notes: Note[];
 };
 
-
+/* @noflow */
 export interface Note {
   uid: number;
   content: string;
@@ -33,6 +35,7 @@ export interface Note {
   user: UserObjectSlim;
 }
 
+/* @noflow */
 export type FlagObject = {
   state: string;
   flagId: number;
@@ -47,6 +50,7 @@ export type FlagObject = {
   reports: Reports;
 } & FlagHistoryObject & FlagNotesObject;
 
+/* @noflow */
 export interface Reports {
   value: string;
   timestamp: number;

--- a/src/types/group.ts
+++ b/src/types/group.ts
@@ -1,5 +1,6 @@
 import { UserObjectSlim } from './user';
 
+/* @noflow */
 export type GroupDataObject = {
   name: string;
   slug: string;
@@ -27,8 +28,10 @@ export type GroupDataObject = {
   memberPostCidsArray: number[];
 };
 
+/* @noflow */
 export type GroupFullObject = GroupDataObject & GroupFullObjectProperties;
 
+/* @noflow */
 export type GroupFullObjectProperties = {
   descriptionParsed: string;
   members: UserObjectSlim[];

--- a/src/types/pagination.ts
+++ b/src/types/pagination.ts
@@ -1,7 +1,9 @@
+/* @noflow */
 export type PaginationObject = {
   pagination: Pagination;
 };
 
+/* @noflow */
 export interface Pagination {
   prev: ActivePage;
   next: ActivePage;

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -2,6 +2,7 @@ import { CategoryObject } from './category';
 import { TopicObject } from './topic';
 import { UserObjectSlim } from './user';
 
+/* @noflow */
 export type PostObject = {
   pid: number;
   tid: number;

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,3 +1,4 @@
+/* @noflow */
 export type SettingsObject = {
   showemail: boolean;
   usePagination: boolean;

--- a/src/types/social.ts
+++ b/src/types/social.ts
@@ -1,3 +1,4 @@
+/* @noflow */
 export type Network = {
   id: string;
   name: string;

--- a/src/types/status.ts
+++ b/src/types/status.ts
@@ -1,3 +1,4 @@
+/* @noflow */
 export type StatusObject = {
   code: string;
   message: string;

--- a/src/types/tag.ts
+++ b/src/types/tag.ts
@@ -1,3 +1,4 @@
+/* @noflow */
 export type TagObject = {
   value: string;
   score: number;

--- a/src/types/topic.ts
+++ b/src/types/topic.ts
@@ -2,9 +2,11 @@ import { CategoryObject } from './category';
 import { TagObject } from './tag';
 import { UserObjectSlim } from './user';
 
+/* @noflow */
 export type TopicObject =
     TopicObjectSlim & TopicObjectCoreProperties & TopicObjectOptionalProperties;
 
+/* @noflow */
 export type TopicObjectCoreProperties = {
   lastposttime: number;
   category: CategoryObject;
@@ -19,6 +21,7 @@ export type TopicObjectCoreProperties = {
   icons: string[];
 };
 
+/* @noflow */
 export type TopicObjectOptionalProperties = {
   tid: number;
   thumb: string;
@@ -38,8 +41,10 @@ interface Teaser {
   index: number;
 }
 
+/* @noflow */
 export type TopicObjectSlim = TopicSlimProperties & TopicSlimOptionalProperties;
 
+/* @noflow */
 export type TopicSlimProperties = {
   tid: number;
   uid: number;
@@ -69,12 +74,14 @@ export type TopicSlimProperties = {
   thumbs: Thumb[];
 };
 
+/* @noflow */
 export type Thumb = {
   id: number;
   name: string;
   url: string;
 };
 
+/* @noflow */
 export type TopicSlimOptionalProperties = {
   tid: number;
   numThumbs: number;

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,6 +1,7 @@
 import { GroupFullObject } from './group';
 import { StatusObject } from './status';
 
+/* @noflow */
 export type UserObjectSlim = {
   uid: number;
   username: string;
@@ -25,12 +26,14 @@ export type UserObjectSlim = {
   banned_until_readable: string;
 };
 
+/* @noflow */
 export type UserObjectACP = UserObjectSlim & {
   administrator: boolean;
   ip: string;
   ips: string[];
 };
 
+/* @noflow */
 export type UserObject = UserObjectSlim & {
   email: string;
   fullname: string;
@@ -51,6 +54,7 @@ export type UserObject = UserObjectSlim & {
   groupTitleArray: string[];
 };
 
+/* @noflow */
 export type UserObjectFull = UserObject & {
   aboutmeParsed: string;
   age: number;
@@ -89,6 +93,7 @@ export type UserObjectFull = UserObject & {
   'email:disableEdit': number;
 };
 
+/* @noflow */
 export type Counts = {
   best: number;
   blocks: number;
@@ -106,6 +111,7 @@ export type Counts = {
   watched: number;
 };
 
+/* @noflow */
 export type ProfileLink = {
   id: string;
   route: string;
@@ -115,6 +121,7 @@ export type ProfileLink = {
   icon: string;
 };
 
+/* @noflow */
 export type Visibility = {
   self: boolean;
   other: boolean;
@@ -124,6 +131,7 @@ export type Visibility = {
   canViewInfo: boolean;
 };
 
+/* @noflow */
 export type SSO = {
   associated: boolean;
   url: string;


### PR DESCRIPTION
Flow is a static type checker for JS. It can be integrated seamlessly with ESLint which our project already uses. I integrated the tool into our project and made sure it passes by fixing the reported issues.

To answer the questions from the project writeup:
How often should this new integration be run (on each pull request? on commits to main?)
   - It will be run at the same time as the original lint check which is on each pull request and commits to main
What level of customization is needed for this tool?
   - I don't know if I understand this question correctly, but the tool can be configured with multiple different flags
How should the integration of this tool be enforced?
   - I don't know if I understand this question correctly, but the tool is now integrated in such a way that it will be enforced at the same level as the ESLint checks were previously (they are still enforced at that level)